### PR TITLE
Add Everforest Dark theme (hard contrast).

### DIFF
--- a/smassh/ui/css/themes/everforest_dark.tcss
+++ b/smassh/ui/css/themes/everforest_dark.tcss
@@ -1,0 +1,10 @@
+$bg-color: #272e33;
+$main-color: #a7c080;
+$caret-color: #d699b6;
+$sub-color: #7A8478;
+$sub-alt-color: #2e383c;
+$text-color: #d3c6aa;
+$error-color: #e67e80;
+$error-extra-color: #e69875;
+$colorful-error-color: #e67e80;
+$colorful-error-extra-color: #e69875;


### PR DESCRIPTION
I added a theme file for Everforest's Hard Dark variant [as seen here](https://github.com/sainnhe/everforest). 

It looks like theme changes aren't recorded in the contribution list, so I left it out here as well. If there's interest I can add other variants of Everforest. 