### PR TITLE
Added other Everforest variations

### DIFF
--- a/smassh/ui/css/themes/everforest_dark_hard.tcss
+++ b/smassh/ui/css/themes/everforest_dark_hard.tcss
@@ -1,8 +1,8 @@
-$bg-color: #2d353b;
+$bg-color: #272e33;
 $main-color: #a7c080;
 $caret-color: #d699b6;
-$sub-color: #7a8478;
-$sub-alt-color: #343f44;
+$sub-color: #7A8478;
+$sub-alt-color: #2e383c;
 $text-color: #d3c6aa;
 $error-color: #e67e80;
 $error-extra-color: #e69875;

--- a/smassh/ui/css/themes/everforest_dark_soft.tcss
+++ b/smassh/ui/css/themes/everforest_dark_soft.tcss
@@ -1,8 +1,8 @@
-$bg-color: #2d353b;
+$bg-color: #333c43;
 $main-color: #a7c080;
 $caret-color: #d699b6;
-$sub-color: #7a8478;
-$sub-alt-color: #343f44;
+$sub-color: #7A8478;
+$sub-alt-color: #3a464c;
 $text-color: #d3c6aa;
 $error-color: #e67e80;
 $error-extra-color: #e69875;

--- a/smassh/ui/css/themes/everforest_light.tcss
+++ b/smassh/ui/css/themes/everforest_light.tcss
@@ -1,0 +1,10 @@
+$bg-color: #fdf6e3;
+$main-color: #8da101;
+$caret-color: #df69ba;
+$sub-color: #a6b0a0;
+$sub-alt-color: #f4f0d9;
+$text-color: #5c6a72;
+$error-color: #f85552;
+$error-extra-color: #f57d26;
+$colorful-error-color: #f85552;
+$colorful-error-extra-color: #f57d26;

--- a/smassh/ui/css/themes/everforest_light_hard.tcss
+++ b/smassh/ui/css/themes/everforest_light_hard.tcss
@@ -1,0 +1,10 @@
+$bg-color: #fffbef;
+$main-color: #8da101;
+$caret-color: #df69ba;
+$sub-color: #a6b0a0;
+$sub-alt-color: #f8f5e4;
+$text-color: #5c6a72;
+$error-color: #f85552;
+$error-extra-color: #f57d26;
+$colorful-error-color: #f85552;
+$colorful-error-extra-color: #f57d26;

--- a/smassh/ui/css/themes/everforest_light_soft.tcss
+++ b/smassh/ui/css/themes/everforest_light_soft.tcss
@@ -1,0 +1,10 @@
+$bg-color: #f3ead3;
+$main-color: #8da101;
+$caret-color: #df69ba;
+$sub-color: #a6b0a0;
+$sub-alt-color: #eae4ca;
+$text-color: #5c6a72;
+$error-color: #f85552;
+$error-extra-color: #f57d26;
+$colorful-error-color: #f85552;
+$colorful-error-extra-color: #f57d26;


### PR DESCRIPTION
Six variants of Everforest: Three contrast variants (hard, medium, soft) in light and dark modes. 

The previous Everforest TCSS represented the dark hard variant, but the default is medium. That change is applied in `everforest_dark.tcss` and the dark hard colors are in `everforest_dark_hard.tcss`.