### PR TITLE
Revert "fix: key events to settings after confirm" to fix the typing issue

### DIFF
--- a/smassh/ui/screens/typing.py
+++ b/smassh/ui/screens/typing.py
@@ -96,5 +96,6 @@ class TypingScreen(BaseWindow):
         if not self.visible:
             return
 
+        event.stop()
         key = event.character if event.is_printable and event.character else event.key
         self.query_one(TypingSpace).keypress(key)


### PR DESCRIPTION
After doing `git bisect`, I found 7efb8660c9bc6b8609a157bcd94ba4732356b71d is the first bad commit. Then I reverted it, and the typing issue is gone.

I don't really know what this commit does, I just want to let you guys know reverting it helps me. If more modification is needed, you can create another PR. I don't know much about the TUI stuff.

Close #82.